### PR TITLE
Remove veterans day and columbus day from CME calendar.

### DIFF
--- a/data/cme.yaml
+++ b/data/cme.yaml
@@ -1,6 +1,6 @@
 # Chicago Mercantile Exchange holidays definition for the Ruby Holiday gem.
 #
-# Updated: 2015-02-06
+# Updated: 2015-11-05
 # 
 # Sources: http://www.cmegroup.com/tools-information/holiday-calendar/
 #  - http://www.futuresemail.com/cot/holiday.htm
@@ -38,15 +38,7 @@ months:
     week: 1
     regions: [cme]
     wday: 1
-  10: 
-  - name: Columbus Day
-    week: 2
-    regions: [cme]
-    wday: 1
   11: 
-  - name: Veterans Day
-    regions: [cme]
-    mday: 11
   - name: Thanksgiving Day
     week: 4
     wday: 4
@@ -74,8 +66,6 @@ tests: |
    Date.civil(2009,5,25) => "Memorial Day",
    Date.civil(2009,7,3) => "Independence Day",
    Date.civil(2009,9,7) => "Labor Day",
-   Date.civil(2009,10,12) => "Columbus Day",
-   Date.civil(2009,11,11) => "Veterans Day",
    Date.civil(2009,11,26) => "Thanksgiving Day",
    Date.civil(2009,12,25) => "Christmas Day",
 
@@ -86,8 +76,6 @@ tests: |
    Date.civil(2010,5,31) => "Memorial Day",
    Date.civil(2010,7,5) => "Independence Day",
    Date.civil(2010,9,6) => "Labor Day",
-   Date.civil(2010,10,11) => "Columbus Day",
-   Date.civil(2010,11,11) => "Veterans Day",
    Date.civil(2010,11,25) => "Thanksgiving Day",
    Date.civil(2010,12,24) => "Christmas Day", 
 
@@ -97,8 +85,6 @@ tests: |
    Date.civil(2011,5,30) => "Memorial Day",
    Date.civil(2011,7,4) => "Independence Day",
    Date.civil(2011,9,5) => "Labor Day",
-   Date.civil(2011,10,10) => "Columbus Day",
-   Date.civil(2011,11,11) => "Veterans Day",
    Date.civil(2011,11,24) => "Thanksgiving Day",
    Date.civil(2011,12,26) => "Christmas Day",
 
@@ -109,8 +95,6 @@ tests: |
    Date.civil(2012,5,28) => "Memorial Day",
    Date.civil(2012,7,4) => "Independence Day",
    Date.civil(2012,9,3) => "Labor Day",
-   Date.civil(2012,10,8) => "Columbus Day",
-   Date.civil(2012,11,11) => "Veterans Day",
    Date.civil(2012,11,22) => "Thanksgiving Day",
    Date.civil(2012,12,25) => "Christmas Day",
 
@@ -121,8 +105,6 @@ tests: |
    Date.civil(2013,5,27) => "Memorial Day",
    Date.civil(2013,7,4) => "Independence Day",
    Date.civil(2013,9,2) => "Labor Day",
-   Date.civil(2013,10,14) => "Columbus Day",
-   Date.civil(2013,11,11) => "Veterans Day",
    Date.civil(2013,11,28) => "Thanksgiving Day",
    Date.civil(2013,12,25) => "Christmas Day",
    
@@ -133,8 +115,6 @@ tests: |
    Date.civil(2014,5,26) => "Memorial Day",
    Date.civil(2014,7,4) => "Independence Day",
    Date.civil(2014,9,1) => "Labor Day",
-   Date.civil(2014,10,13) => "Columbus Day",
-   Date.civil(2014,11,11) => "Veterans Day",
    Date.civil(2014,11,27) => "Thanksgiving Day",
    Date.civil(2014,12,25) => "Christmas Day",
    
@@ -145,8 +125,6 @@ tests: |
    Date.civil(2015,5,25) => "Memorial Day",
    Date.civil(2015,7,3) => "Independence Day",
    Date.civil(2015,9,7) => "Labor Day",
-   Date.civil(2015,10,12) => "Columbus Day",
-   Date.civil(2015,11,11) => "Veterans Day",
    Date.civil(2015,11,26) => "Thanksgiving Day",
    Date.civil(2015,12,25) => "Christmas Day"
 

--- a/lib/holidays/cme.rb
+++ b/lib/holidays/cme.rb
@@ -25,9 +25,7 @@ module Holidays
       5 => [{:wday => 1, :week => -1, :name => "Memorial Day", :regions => [:cme]}],
       7 => [{:mday => 4, :observed => lambda { |date| Holidays.to_monday_if_sunday_to_friday_if_saturday(date) }, :observed_id => "to_monday_if_sunday_to_friday_if_saturday", :name => "Independence Day", :regions => [:cme]}],
       9 => [{:wday => 1, :week => 1, :name => "Labor Day", :regions => [:cme]}],
-      10 => [{:wday => 1, :week => 2, :name => "Columbus Day", :regions => [:cme]}],
-      11 => [{:mday => 11, :name => "Veterans Day", :regions => [:cme]},
-            {:wday => 4, :week => 4, :name => "Thanksgiving Day", :regions => [:cme]}],
+      11 => [{:wday => 4, :week => 4, :name => "Thanksgiving Day", :regions => [:cme]}],
       12 => [{:mday => 25, :observed => lambda { |date| Holidays.to_monday_if_sunday_to_friday_if_saturday(date) }, :observed_id => "to_monday_if_sunday_to_friday_if_saturday", :name => "Christmas Day", :regions => [:cme]}]
       }
     end

--- a/test/defs/test_defs_cme.rb
+++ b/test/defs/test_defs_cme.rb
@@ -14,8 +14,6 @@ class CmeDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2009,5,25) => "Memorial Day",
  Date.civil(2009,7,3) => "Independence Day",
  Date.civil(2009,9,7) => "Labor Day",
- Date.civil(2009,10,12) => "Columbus Day",
- Date.civil(2009,11,11) => "Veterans Day",
  Date.civil(2009,11,26) => "Thanksgiving Day",
  Date.civil(2009,12,25) => "Christmas Day",
 
@@ -26,8 +24,6 @@ class CmeDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2010,5,31) => "Memorial Day",
  Date.civil(2010,7,5) => "Independence Day",
  Date.civil(2010,9,6) => "Labor Day",
- Date.civil(2010,10,11) => "Columbus Day",
- Date.civil(2010,11,11) => "Veterans Day",
  Date.civil(2010,11,25) => "Thanksgiving Day",
  Date.civil(2010,12,24) => "Christmas Day", 
 
@@ -37,8 +33,6 @@ class CmeDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2011,5,30) => "Memorial Day",
  Date.civil(2011,7,4) => "Independence Day",
  Date.civil(2011,9,5) => "Labor Day",
- Date.civil(2011,10,10) => "Columbus Day",
- Date.civil(2011,11,11) => "Veterans Day",
  Date.civil(2011,11,24) => "Thanksgiving Day",
  Date.civil(2011,12,26) => "Christmas Day",
 
@@ -49,8 +43,6 @@ class CmeDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2012,5,28) => "Memorial Day",
  Date.civil(2012,7,4) => "Independence Day",
  Date.civil(2012,9,3) => "Labor Day",
- Date.civil(2012,10,8) => "Columbus Day",
- Date.civil(2012,11,11) => "Veterans Day",
  Date.civil(2012,11,22) => "Thanksgiving Day",
  Date.civil(2012,12,25) => "Christmas Day",
 
@@ -61,8 +53,6 @@ class CmeDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2013,5,27) => "Memorial Day",
  Date.civil(2013,7,4) => "Independence Day",
  Date.civil(2013,9,2) => "Labor Day",
- Date.civil(2013,10,14) => "Columbus Day",
- Date.civil(2013,11,11) => "Veterans Day",
  Date.civil(2013,11,28) => "Thanksgiving Day",
  Date.civil(2013,12,25) => "Christmas Day",
  
@@ -73,8 +63,6 @@ class CmeDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2014,5,26) => "Memorial Day",
  Date.civil(2014,7,4) => "Independence Day",
  Date.civil(2014,9,1) => "Labor Day",
- Date.civil(2014,10,13) => "Columbus Day",
- Date.civil(2014,11,11) => "Veterans Day",
  Date.civil(2014,11,27) => "Thanksgiving Day",
  Date.civil(2014,12,25) => "Christmas Day",
  
@@ -85,8 +73,6 @@ class CmeDefinitionTests < Test::Unit::TestCase  # :nodoc:
  Date.civil(2015,5,25) => "Memorial Day",
  Date.civil(2015,7,3) => "Independence Day",
  Date.civil(2015,9,7) => "Labor Day",
- Date.civil(2015,10,12) => "Columbus Day",
- Date.civil(2015,11,11) => "Veterans Day",
  Date.civil(2015,11,26) => "Thanksgiving Day",
  Date.civil(2015,12,25) => "Christmas Day"
 


### PR DESCRIPTION
Those days aren't actually needed.